### PR TITLE
fix: Add missing psycopg2 import in dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import plotly.graph_objects as go
 import os
+import psycopg2
 
 # ==============================================================================
 # Page Configuration


### PR DESCRIPTION
This commit fixes a `NameError` that occurred when running the Streamlit dashboard. The `psycopg2` library was used to connect to the database, but the module itself was not imported.

The fix adds the required `import psycopg2` statement to the top of `dashboard.py`, resolving the crash.