### PR TITLE
feat: Allow users to add new stock tickers

### DIFF
--- a/pages/1_Dashboard.py
+++ b/pages/1_Dashboard.py
@@ -7,7 +7,8 @@ from streamlit_autorefresh import st_autorefresh
 
 # Add src to path to import dashboard_utils
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
-from dashboard_utils import load_data
+from dashboard_utils import load_data, add_ticker_to_config
+import subprocess
 
 st.set_page_config(
     page_title="Dashboard",
@@ -48,6 +49,31 @@ selected_start_date, selected_end_date = st.sidebar.date_input(
     min_value=min_date,
     max_value=max_date,
 )
+
+# --- Add New Ticker ---
+st.sidebar.markdown("---")
+st.sidebar.header("Add New Ticker")
+new_ticker = st.sidebar.text_input("Enter a new stock ticker (e.g., GOOGL):")
+if st.sidebar.button("Add Ticker"):
+    if new_ticker:
+        st.sidebar.info(f"Adding {new_ticker.upper()}... this may take a moment.")
+        add_ticker_to_config(new_ticker)
+
+        # Run the pipeline for the new ticker
+        result = subprocess.run(
+            ["python", "run_pipeline.py", "--ticker", new_ticker, "--skip-db"],
+            capture_output=True, text=True
+        )
+
+        if result.returncode == 0:
+            st.sidebar.success(f"Ticker {new_ticker.upper()} added successfully!")
+            # Clear cache and rerun
+            st.cache_data.clear()
+            st.experimental_rerun()
+        else:
+            st.sidebar.error(f"Failed to add ticker. Error:\n{result.stderr}")
+    else:
+        st.sidebar.warning("Please enter a ticker.")
 
 if selected_start_date > selected_end_date:
     st.sidebar.error("Error: Start date must be before end date.")

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -222,14 +222,21 @@ def upsert_data_to_db(conn, df):
 # ============================================================================== 
 def run_the_pipeline(args):
     """Main ETL pipeline logic."""
-    stock_df = fetch_stock_data(config.TICKERS)
+    if args.ticker:
+        tickers = [args.ticker.upper()]
+        print(f"Running pipeline for single ticker: {tickers[0]}")
+    else:
+        tickers = config.TICKERS
+        print("Running pipeline for all tickers in config.py")
+
+    stock_df = fetch_stock_data(tickers)
 
     if config.FINLIGHT_API_KEY == "YOUR_API_KEY_HERE":
         print("WARNING: Finlight API key is not set in config.py. Skipping news fetching.")
         news_df = pd.DataFrame()
     else:
         api = FinlightApi(ApiConfig(api_key=config.FINLIGHT_API_KEY))
-        news_df = fetch_all_news(api, config.TICKERS)
+        news_df = fetch_all_news(api, tickers)
 
     if stock_df is not None:
         final_df = transform_data(stock_df, news_df)
@@ -265,6 +272,7 @@ def get_pipeline_args():
     """Sets up and parses command-line arguments for the pipeline."""
     parser = argparse.ArgumentParser(description="Run the full data pipeline for stock and news sentiment analysis.")
     parser.add_argument("--skip-db", action="store_true", help="Skip all database operations.")
+    parser.add_argument("--ticker", type=str, help="Run the pipeline for a single stock ticker.")
     return parser
 
 if __name__ == "__main__":

--- a/src/dashboard_utils.py
+++ b/src/dashboard_utils.py
@@ -37,3 +37,31 @@ def load_data():
         except FileNotFoundError:
             st.error(f"Fatal Error: Could not connect to the database AND the fallback file '{config.PROCESSED_CSV_PATH}' was not found.")
             return None, "error"
+
+def add_ticker_to_config(ticker):
+    """
+    Adds a new ticker to the TICKERS list in the config.py file.
+    """
+    import re
+    with open('config.py', 'r') as f:
+        content = f.read()
+
+    tickers_list_str_match = re.search(r'TICKERS = \[(.*?)\]', content)
+    if tickers_list_str_match:
+        tickers_list_str = tickers_list_str_match.group(1)
+        tickers = [t.strip().strip("'\"") for t in tickers_list_str.split(',') if t.strip()]
+    else:
+        tickers = []
+
+    if ticker.upper() not in tickers:
+        tickers.append(ticker.upper())
+        new_tickers_list_str = ', '.join([f'"{t}"' for t in tickers])
+
+        if tickers_list_str_match:
+            new_content = re.sub(r'TICKERS = \[.*?\]', f'TICKERS = [{new_tickers_list_str}]', content)
+        else:
+            # If TICKERS list not found, add it to the end of the file.
+            new_content = content + f'\nTICKERS = [{new_tickers_list_str}]\n'
+
+        with open('config.py', 'w') as f:
+            f.write(new_content)

--- a/test_add_ticker.py
+++ b/test_add_ticker.py
@@ -1,0 +1,6 @@
+import sys
+sys.path.append('src')
+from dashboard_utils import add_ticker_to_config
+
+add_ticker_to_config('MSFT')
+print("Ticker 'MSFT' added to config.")


### PR DESCRIPTION
This change introduces a new feature that allows users to add new stock tickers to the dashboard dynamically.

Key changes:
- Added a text input and a button to the dashboard sidebar to allow users to add new tickers.
- Modified `run_pipeline.py` to accept a `--ticker` argument to run the pipeline for a single ticker.
- Updated the dashboard to call the pipeline for the new ticker and refresh the data.
- Added a utility function to update the `config.py` file with the new ticker.