### PR TITLE
fix(ml): Exclude target variable from scaler training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ scikit-learn
 xgboost
 streamlit-autorefresh
 schedule
+pytest
 

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -62,7 +62,8 @@ def generate_ml_data(api_key):
 def prepare_data_for_training(df):
     """Splits and scales the feature-engineered data."""
     print("\n--- Step 2: Splitting and Scaling Data ---")
-    X = df.drop(columns=[TARGET_VARIABLE, 'Date', 'Ticker'])
+    # Drop the target, identifiers, and the source of the target ('next_day_close')
+    X = df.drop(columns=[TARGET_VARIABLE, 'Date', 'Ticker', 'next_day_close'])
     y = df[TARGET_VARIABLE]
 
     split_index = int(len(df) * TRAIN_SPLIT_FRACTION)


### PR DESCRIPTION
The training script was incorrectly including the 'next_day_close' column, which is the source of the target variable, in the feature set before fitting the StandardScaler. This caused a ValueError during prediction because the feature sets did not match.

This commit corrects the training logic by explicitly dropping 'next_day_close' from the features DataFrame (X) before the scaler is fit.

feat: Add pytest to requirements

Adds `pytest` to the `requirements.txt` file to ensure a consistent and reproducible testing environment for all developers.