### PR TITLE
fix: Handle timezone-aware and naive datetime mixing

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -24,7 +24,6 @@ from src.sentiment_analysis import analyze_vader_sentiment, analyze_finbert_sent
 from src.reddit_client import fetch_reddit_data
 from src.twitter_client import fetch_twitter_data
 
-
 # ============================================================================== 
 # STEP 1: STOCK DATA EXTRACTION
 # ============================================================================== 
@@ -114,7 +113,7 @@ def transform_data(stock_df, news_df):
     news_with_sentiment['finbert_weighted_score'] = (
         news_with_sentiment['finbert_numeric_score'] * news_with_sentiment['finbert_score']
     )
-    news_with_sentiment['Date'] = pd.to_datetime(news_with_sentiment['publish_date']).dt.date
+    news_with_sentiment['Date'] = pd.to_datetime(news_with_sentiment['publish_date'], utc=True).dt.date
     # Aggregate sentiment and collect headlines
     def join_titles(series):
         """Joins titles into a single string, handling potential non-string data."""
@@ -270,7 +269,6 @@ def run_the_pipeline(args):
     twitter_df = fetch_twitter_data(tickers)
     if not twitter_df.empty:
         all_news_dfs.append(twitter_df)
-
 
     # --- Combine News Sources ---
     if all_news_dfs:


### PR DESCRIPTION
This commit resolves a ValueError that occurred during data transformation when combining news sources with different timezone formats. The fix standardizes all 'publish_date' timestamps to UTC before converting them to dates.