### PR TITLE
fix: Add sentencepiece dependency for ABSA model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ Bokeh
 praw
 tweepy
 bertopic
+sentencepiece

--- a/src/advanced_analysis.py
+++ b/src/advanced_analysis.py
@@ -37,7 +37,6 @@ def generate_summary(articles_df: pd.DataFrame) -> str:
     if not full_text.strip():
         return "The provided articles are empty."
 
-
     try:
         # Generate the summary. Let the pipeline handle truncation automatically.
         summary_result = summarizer(
@@ -47,7 +46,6 @@ def generate_summary(articles_df: pd.DataFrame) -> str:
             do_sample=False,
             truncation=True  # Let the pipeline handle long texts
         )
-
         return summary_result[0]['summary_text']
     except Exception as e:
         print(f"Error during summarization: {e}")
@@ -107,7 +105,6 @@ try:
         model="yangheng/deberta-v3-base-absa-v1.1",
         use_fast=False
     )
-
     print("ABSA pipeline initialized successfully.")
 except Exception as e:
     print(f"CRITICAL: Failed to initialize ABSA pipeline: {e}")


### PR DESCRIPTION
This commit adds the 'sentencepiece' library to the project's dependencies. This is required by the DebertaV2Tokenizer used in the Aspect-Based Sentiment Analysis (ABSA) model and resolves a critical error during pipeline initialization.