### PR TITLE
fix(backtester): Ensure trades are executed correctly

### DIFF
--- a/pages/4_Backtester.py
+++ b/pages/4_Backtester.py
@@ -106,13 +106,15 @@ if st.button("Run Backtest"):
             # Set the Date as the index
             backtest_data = backtest_data.set_index('Date')
 
-            # Configure the strategy with user-defined parameters
-            class CustomSentimentStrategy(SentimentStrategy):
-                buy_sentiment_threshold = buy_threshold
-                sell_sentiment_threshold = sell_threshold
-
             try:
-                stats = run_backtest(backtest_data, CustomSentimentStrategy, cash=initial_cash)
+                # Run the backtest, passing the thresholds as keyword arguments
+                stats = run_backtest(
+                    backtest_data,
+                    SentimentStrategy,
+                    cash=initial_cash,
+                    buy_sentiment_threshold=buy_threshold,
+                    sell_sentiment_threshold=sell_threshold
+                )
 
                 st.subheader("Backtest Results")
                 st.write(f"Results for **{selected_ticker}** from **{start_date}** to **{end_date}**")

--- a/src/advanced_analysis.py
+++ b/src/advanced_analysis.py
@@ -30,9 +30,10 @@ def generate_summary(articles_df: pd.DataFrame) -> str:
     if articles_df.empty or 'title' not in articles_df.columns:
         return "No articles provided to summarize."
 
-    # Concatenate all article titles/texts into a single block of text.
-    # Using a separator to help the model distinguish between articles.
-    full_text = ". ".join(articles_df['title'].astype(str).tolist())
+    # Drop missing values, convert to string, and concatenate into a single text block.
+    # This prevents 'nan' strings from being passed to the model.
+    valid_titles = articles_df['title'].dropna().astype(str)
+    full_text = ". ".join(valid_titles.tolist())
 
     if not full_text.strip():
         return "The provided articles are empty."

--- a/src/backtesting_engine.py
+++ b/src/backtesting_engine.py
@@ -24,16 +24,19 @@ class SentimentStrategy(Strategy):
         Define the trading logic for the next data point (e.g., the next day).
         This is called for each data point in the dataset.
         """
+        # Use the current sentiment value for decision making.
+        current_sentiment = self.sentiment[0]
+
         # If we have no position and sentiment is strongly positive, go long.
-        if not self.position and self.sentiment[-1] > self.buy_sentiment_threshold:
+        if not self.position and current_sentiment > self.buy_sentiment_threshold:
             self.buy()
 
         # If we have a position and sentiment turns negative, close the position.
-        elif self.position and self.sentiment[-1] < self.sell_sentiment_threshold:
+        elif self.position and current_sentiment < self.sell_sentiment_threshold:
             self.position.close()
 
 
-def run_backtest(data: pd.DataFrame, strategy: Strategy, cash: int = 10000, commission: float = 0.002):
+def run_backtest(data: pd.DataFrame, strategy: Strategy, cash: int = 10000, commission: float = 0.002, **kwargs):
     """
     Runs a backtest on the given data using the specified strategy.
 
@@ -42,6 +45,7 @@ def run_backtest(data: pd.DataFrame, strategy: Strategy, cash: int = 10000, comm
         strategy (Strategy): The strategy class to use for the backtest.
         cash (int, optional): The initial cash amount. Defaults to 10000.
         commission (float, optional): The commission rate for each trade. Defaults to 0.002.
+        **kwargs: Additional keyword arguments to pass to the strategy.
 
     Returns:
         A pandas Series with the backtest statistics.
@@ -55,7 +59,9 @@ def run_backtest(data: pd.DataFrame, strategy: Strategy, cash: int = 10000, comm
     # 'Open', 'High', 'Low', 'Close', 'Volume'
 
     bt = Backtest(data, strategy, cash=cash, commission=commission)
-    stats = bt.run()
+
+    # Pass strategy parameters via kwargs to bt.run()
+    stats = bt.run(**kwargs)
 
     # The bt.plot() function opens a browser window, which is not ideal for Streamlit.
     # We will return the stats object and let the Streamlit page handle the plotting if needed.


### PR DESCRIPTION
The backtesting engine was not executing trades because of two issues:
1. Strategy parameters (buy/sell thresholds) from the UI were not being passed correctly to the backtesting engine.
2. The trading logic was using the previous day's sentiment score, which, while a valid strategy, is less direct and was contributing to the confusion.

This commit fixes these issues by:
- Refactoring `run_backtest` to accept `**kwargs` and pass them to the strategy, making parameter passing explicit and reliable.
- Updating the backtester page to use this new method, removing the on-the-fly class creation.
- Changing the strategy to use the current day's sentiment score for trading decisions.