### PR TITLE
feat: Add GitHub Actions workflow for CI/CD

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest


### PR DESCRIPTION
Introduces a GitHub Actions workflow to automatically build and push the application's Docker image to Docker Hub.

- The workflow is defined in `.github/workflows/docker-build.yml`.
- It triggers on every push to the `main` branch.
- It uses GitHub secrets to securely authenticate with Docker Hub.
- The built image is tagged with the repository name and pushed to the user's Docker Hub account.