### PR TITLE
fix: Set AWS region to us-east-1 for ECR Public login

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: us-east-1 # ECR Public login must use us-east-1
 
       - name: Login to Amazon ECR Public
         uses: aws-actions/amazon-ecr-login@v1


### PR DESCRIPTION
Corrects the GitHub Actions workflow to use the `us-east-1` region when configuring AWS credentials.

This is a specific requirement for authenticating with the Amazon ECR Public registry, and it resolves the `getaddrinfo ENOTFOUND` error that occurred when using other regions.